### PR TITLE
Improve AppBar navigation: hover dropdown and mobile menu

### DIFF
--- a/src/components/is-appbar.js
+++ b/src/components/is-appbar.js
@@ -28,20 +28,20 @@ const useStyles = makeStyles((theme) => ({
     flexGrow: 1,
     color: 'inherit',
   },
-  navButtons3: {
+  navMedium: {
     textTransform: 'inherit',
     color: 'inherit',
     [theme.breakpoints.down('xs')]: { display: 'none', },
   },
-  navButtons6: {
+  navLarge: {
     textTransform: 'inherit',
     color: 'inherit',
     [theme.breakpoints.down('md')]: { display: 'none', },
   },
-  navMenu3: {
+  menuMedium: {
     [theme.breakpoints.up('sm')]: { display: 'none', },
   },
-  navMenu6: {
+  menuLarge: {
     [theme.breakpoints.up('lg')]: { display: 'none', },
   },
 }));
@@ -65,10 +65,10 @@ const NamedDefault = () => {
         <Typography variant="h5" className={classes.title}>
           <Link to="/" className={GlobalCSS.nostyleLink}>Intentional Society</Link>
         </Typography>
-        <Button className={classes.navButtons3} component={Link} to="/about">About</Button>
-        <Button className={classes.navButtons3} component={Link} to="/get-involved">Get Involved</Button>
+        <Button className={classes.navMedium} component={Link} to="/about">About</Button>
+        <Button className={classes.navMedium} component={Link} to="/get-involved">Get Involved</Button>
         <Button
-          className={classes.navButtons3}
+          className={classes.navMedium}
           onClick={(event) => setSpacesAnchor(event.currentTarget)}
         >
           Spaces
@@ -86,17 +86,17 @@ const NamedDefault = () => {
           <MenuItem onClick={() => { setSpacesAnchor(null); navigate('/community'); }}>Community</MenuItem>
           <MenuItem onClick={() => { setSpacesAnchor(null); navigate('/iv'); }}>Ventures</MenuItem>
         </Menu>
-        <Button className={classes.navButtons3} component={Link} to="/history">History</Button>
-        <Button className={classes.navButtons6} component={Link} to="/friends">Friends</Button>
-        <Button className={classes.navButtons6} component={Link} to="/questions">Questions?</Button>
-        <Button className={classes.navButtons6} component={Link} to="/resources">Resources</Button>
+        <Button className={classes.navMedium} component={Link} to="/history">History</Button>
+        <Button className={classes.navLarge} component={Link} to="/friends">Friends</Button>
+        <Button className={classes.navLarge} component={Link} to="/questions">Questions?</Button>
+        <Button className={classes.navLarge} component={Link} to="/resources">Resources</Button>
         <IconButton aria-controls="top-nav-menu" aria-haspopup="true" aria-label="menu"
                     className={classes.menuButton} onClick={handleClick}>
           <MenuIcon />
         </IconButton>
         <Menu
           id="top-nav-menu"
-          className={classes.navMenu6}
+          className={classes.menuLarge}
           anchorEl={anchorEl}
           anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
           transformOrigin={{ vertical: 'top', horizontal: 'right' }}
@@ -104,10 +104,10 @@ const NamedDefault = () => {
           open={Boolean(anchorEl)}
           onClose={handleClose}
         >
-          <MenuItem className={classes.navMenu3} component={Link} to="/about" onClick={handleClose}>About</MenuItem>
-          <MenuItem className={classes.navMenu3} component={Link} to="/get-involved" onClick={handleClose}>Get Involved!</MenuItem>
+          <MenuItem className={classes.menuMedium} component={Link} to="/about" onClick={handleClose}>About</MenuItem>
+          <MenuItem className={classes.menuMedium} component={Link} to="/get-involved" onClick={handleClose}>Get Involved!</MenuItem>
           <MenuItem
-            className={classes.navMenu3}
+            className={classes.menuMedium}
             onClick={(event) => setSpacesAnchor(event.currentTarget)}
           >
             Spaces
@@ -124,7 +124,7 @@ const NamedDefault = () => {
             <MenuItem onClick={() => { setSpacesAnchor(null); navigate('/community'); }}>Community</MenuItem>
             <MenuItem onClick={() => { setSpacesAnchor(null); navigate('/iv'); }}>Ventures</MenuItem>
           </Menu>
-          <MenuItem className={classes.navMenu3} component={Link} to="/history" onClick={handleClose}>History</MenuItem>
+          <MenuItem className={classes.menuMedium} component={Link} to="/history" onClick={handleClose}>History</MenuItem>
           <MenuItem component={Link} to="/friends" onClick={handleClose}>Friends</MenuItem>
           <MenuItem component={Link} to="/questions" onClick={handleClose}>Questions?</MenuItem>
           <MenuItem component={Link} to="/resources" onClick={handleClose}>Resources</MenuItem>

--- a/src/components/is-appbar.js
+++ b/src/components/is-appbar.js
@@ -106,24 +106,9 @@ const NamedDefault = () => {
         >
           <MenuItem className={classes.menuMedium} component={Link} to="/about" onClick={handleClose}>About</MenuItem>
           <MenuItem className={classes.menuMedium} component={Link} to="/get-involved" onClick={handleClose}>Get Involved!</MenuItem>
-          <MenuItem
-            className={classes.menuMedium}
-            onClick={(event) => setSpacesAnchor(event.currentTarget)}
-          >
-            Spaces
-          </MenuItem>
-          <Menu
-            anchorEl={spacesAnchor}
-            open={Boolean(spacesAnchor)}
-            onClose={() => setSpacesAnchor(null)}
-            anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-            transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-            getContentAnchorEl={null}
-          >
-            <MenuItem onClick={() => { setSpacesAnchor(null); navigate('/dojo'); }}>Dojo</MenuItem>
-            <MenuItem onClick={() => { setSpacesAnchor(null); navigate('/community'); }}>Community</MenuItem>
-            <MenuItem onClick={() => { setSpacesAnchor(null); navigate('/iv'); }}>Ventures</MenuItem>
-          </Menu>
+          <MenuItem className={classes.menuMedium} component={Link} to="/dojo" onClick={handleClose}>Dojo</MenuItem>
+          <MenuItem className={classes.menuMedium} component={Link} to="/community" onClick={handleClose}>Community</MenuItem>
+          <MenuItem className={classes.menuMedium} component={Link} to="/iv" onClick={handleClose}>Ventures</MenuItem>
           <MenuItem className={classes.menuMedium} component={Link} to="/history" onClick={handleClose}>History</MenuItem>
           <MenuItem component={Link} to="/friends" onClick={handleClose}>Friends</MenuItem>
           <MenuItem component={Link} to="/questions" onClick={handleClose}>Questions?</MenuItem>

--- a/src/components/is-appbar.js
+++ b/src/components/is-appbar.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Link } from 'gatsby';
 import { makeStyles } from '@material-ui/core/styles';
 import * as GlobalCSS from '../styles/global.module.css';
@@ -50,6 +50,35 @@ const NamedDefault = () => {
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = useState(null);
   const [spacesAnchor, setSpacesAnchor] = useState(null);
+  const [canHover, setCanHover] = useState(false);
+  const closeTimeoutRef = useRef(null);
+
+  useEffect(() => {
+    setCanHover(window.matchMedia('(hover: hover)').matches);
+  }, []);
+
+  const openSpacesMenu = (event) => {
+    if (closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current);
+    }
+    setSpacesAnchor(event.currentTarget);
+  };
+
+  const closeSpacesMenu = () => {
+    setSpacesAnchor(null);
+  };
+
+  const handleSpacesButtonLeave = () => {
+    closeTimeoutRef.current = setTimeout(() => {
+      closeSpacesMenu();
+    }, 100);
+  };
+
+  const handleSpacesMenuEnter = () => {
+    if (closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current);
+    }
+  };
 
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
@@ -69,7 +98,9 @@ const NamedDefault = () => {
         <Button className={classes.buttonsMedium} component={Link} to="/get-involved">Get Involved</Button>
         <Button
           className={classes.buttonsMedium}
-          onClick={(event) => setSpacesAnchor(event.currentTarget)}
+          onClick={canHover ? undefined : openSpacesMenu}
+          onMouseEnter={canHover ? openSpacesMenu : undefined}
+          onMouseLeave={canHover ? handleSpacesButtonLeave : undefined}
         >
           Spaces
         </Button>
@@ -77,10 +108,14 @@ const NamedDefault = () => {
         <Menu
           anchorEl={spacesAnchor}
           open={Boolean(spacesAnchor)}
-          onClose={() => setSpacesAnchor(null)}
+          onClose={closeSpacesMenu}
           anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
           transformOrigin={{ vertical: 'top', horizontal: 'left' }}
           getContentAnchorEl={null}
+          MenuListProps={{
+            onMouseEnter: canHover ? handleSpacesMenuEnter : undefined,
+            onMouseLeave: canHover ? closeSpacesMenu : undefined,
+          }}
         >
           <MenuItem onClick={() => { setSpacesAnchor(null); navigate('/dojo'); }}>Dojo</MenuItem>
           <MenuItem onClick={() => { setSpacesAnchor(null); navigate('/community'); }}>Community</MenuItem>

--- a/src/components/is-appbar.js
+++ b/src/components/is-appbar.js
@@ -28,12 +28,12 @@ const useStyles = makeStyles((theme) => ({
     flexGrow: 1,
     color: 'inherit',
   },
-  navMedium: {
+  buttonsMedium: {
     textTransform: 'inherit',
     color: 'inherit',
     [theme.breakpoints.down('xs')]: { display: 'none', },
   },
-  navLarge: {
+  buttonsLarge: {
     textTransform: 'inherit',
     color: 'inherit',
     [theme.breakpoints.down('md')]: { display: 'none', },
@@ -65,10 +65,10 @@ const NamedDefault = () => {
         <Typography variant="h5" className={classes.title}>
           <Link to="/" className={GlobalCSS.nostyleLink}>Intentional Society</Link>
         </Typography>
-        <Button className={classes.navMedium} component={Link} to="/about">About</Button>
-        <Button className={classes.navMedium} component={Link} to="/get-involved">Get Involved</Button>
+        <Button className={classes.buttonsMedium} component={Link} to="/about">About</Button>
+        <Button className={classes.buttonsMedium} component={Link} to="/get-involved">Get Involved</Button>
         <Button
-          className={classes.navMedium}
+          className={classes.buttonsMedium}
           onClick={(event) => setSpacesAnchor(event.currentTarget)}
         >
           Spaces
@@ -86,10 +86,10 @@ const NamedDefault = () => {
           <MenuItem onClick={() => { setSpacesAnchor(null); navigate('/community'); }}>Community</MenuItem>
           <MenuItem onClick={() => { setSpacesAnchor(null); navigate('/iv'); }}>Ventures</MenuItem>
         </Menu>
-        <Button className={classes.navMedium} component={Link} to="/history">History</Button>
-        <Button className={classes.navLarge} component={Link} to="/friends">Friends</Button>
-        <Button className={classes.navLarge} component={Link} to="/questions">Questions?</Button>
-        <Button className={classes.navLarge} component={Link} to="/resources">Resources</Button>
+        <Button className={classes.buttonsMedium} component={Link} to="/history">History</Button>
+        <Button className={classes.buttonsLarge} component={Link} to="/friends">Friends</Button>
+        <Button className={classes.buttonsLarge} component={Link} to="/questions">Questions?</Button>
+        <Button className={classes.buttonsLarge} component={Link} to="/resources">Resources</Button>
         <IconButton aria-controls="top-nav-menu" aria-haspopup="true" aria-label="menu"
                     className={classes.menuButton} onClick={handleClick}>
           <MenuIcon />


### PR DESCRIPTION
Body:
  ## Summary
  - Rename cryptic responsive CSS classes for clarity (`navButtons3` → `buttonsMedium`, etc.)
  - Flatten Spaces submenu on mobile - Dojo/Community/Ventures now appear directly in hamburger menu
  - Add hover-to-open behavior for Spaces dropdown on desktop (touch devices retain tap behavior)

  ## Changes
  1. **Class naming**: `navButtons3/6` → `buttonsMedium/Large`, `navMenu3/6` → `menuMedium/Large`
  2. **Mobile UX**: Removed nested "Spaces" submenu in hamburger menu, items appear inline
  3. **Desktop UX**: Spaces dropdown opens on hover using `matchMedia('(hover: hover)')` detection

  ## Test plan
  - [ ] Desktop: Hover over "Spaces" button opens dropdown, moving away closes it
  - [ ] Mobile/tablet: Tap "Spaces" opens dropdown, tap outside closes
  - [ ] Mobile hamburger menu shows Dojo/Community/Ventures directly (no "Spaces" parent)
  - [ ] Medium screens (sm-md): Nav bar shows first 4 buttons + hamburger with remaining items