### PR TITLE
Add dropdown arrow to Spaces button

### DIFF
--- a/src/components/is-appbar.js
+++ b/src/components/is-appbar.js
@@ -10,6 +10,7 @@ import Button from '@material-ui/core/Button';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import MenuIcon from '@material-ui/icons/Menu';
+import ArrowDropDown from '@material-ui/icons/ArrowDropDown';
 import { navigate } from 'gatsby';
 
 const useStyles = makeStyles((theme) => ({
@@ -71,7 +72,7 @@ const NamedDefault = () => {
           className={classes.buttonsMedium}
           onClick={(event) => setSpacesAnchor(event.currentTarget)}
         >
-          Spaces
+          Spaces <ArrowDropDown fontSize="small" />
         </Button>
 
         <Menu


### PR DESCRIPTION
## Summary
Adds a dropdown arrow icon (▼) next to the "Spaces" button to indicate it opens a menu rather than navigating directly to a page.

## Changes
- Import `ArrowDropDown` icon from Material-UI
- Add icon next to "Spaces" text in nav bar button

## Test plan
- [x] Verify arrow appears next to "Spaces" in nav bar on medium+ screens
- [x] Verify dropdown menu still opens on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)