### PR TITLE
Upgrade Node from 14 to 22 LTS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,10 +28,7 @@ yarn format
 yarn clean
 ```
 
-**Node version requirement**: Pinned to Node 14.17.0. For Node > 17, use:
-```bash
-NODE_OPTIONS=--openssl-legacy-provider yarn gatsby build
-```
+**Node version requirement**: Node 22 LTS (configured in `netlify.toml`).
 
 ## Architecture
 
@@ -40,9 +37,10 @@ NODE_OPTIONS=--openssl-legacy-provider yarn gatsby build
 **Layout pattern**: All pages wrap content in `<Layout>` (header/footer) and typically `<CenteredColumn>` for consistent width.
 
 **Styling stack**:
-- Material-UI v4 components for UI (AppBar, Typography, Button, etc.)
+- MUI v5 components for UI (AppBar, Typography, Button, etc.)
+- Emotion for CSS-in-JS (via `gatsby-plugin-emotion`)
 - CSS Modules (`.module.css`) for scoped styles
-- Custom Material-UI theme in `src/gatsby-theme-material-ui-top-layout/theme.js` (primary: teal #24818E, background: #E8F0EC)
+- Custom MUI theme in `src/gatsby-theme-material-ui-top-layout/theme.js` (primary: teal #24818E, background: #E8F0EC)
 
 **Key components**:
 - `src/components/layout.js` - Root layout with navigation

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,8 +7,7 @@
   publish = "public/"
 
 [build.environment]
-  PYTHON_VERSION = "3.10" #3.11 broke our old version of gyp (used by sharp)
-  NODE_VERSION =  "14.17.0" # previously used "12.16.1"
+  NODE_VERSION = "22"
 
 [[redirects]]
   from = "/who-we-are"


### PR DESCRIPTION
## Summary
- Update NODE_VERSION in netlify.toml from 14.17.0 to 22
- Remove outdated Python version workaround (no longer needed with modern sharp)
- Update CLAUDE.md to reflect Node 22 and MUI v5

## Why Node 22?
- Node 14 is EOL
- Node 22 LTS is supported until April 2027
- Required for upcoming Gatsby 5 upgrade (which needs Node 18+)

## Test plan
- [x] Verify Netlify deploy preview builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)