### PR TITLE
Replace gatsby-plugin-gtag with official gatsby-plugin-google-gtag

### DIFF
--- a/src/components/layout.module.css
+++ b/src/components/layout.module.css
@@ -5,8 +5,7 @@
 }
 
 body {
-  font-family: "Ovo", 'Times New Roman', Times, serif;
-  font-size: 120%;
+  /* font-family and font-size now set in theme.js */
   color: #08080F;
   background-color: #E8F0EC;
 }

--- a/src/gatsby-theme-material-ui-top-layout/theme.js
+++ b/src/gatsby-theme-material-ui-top-layout/theme.js
@@ -18,6 +18,15 @@ const theme = createTheme({
     h5: { fontFamily: gudeaFont },
     h6: { fontFamily: gudeaFont },
   },
+  components: {
+    MuiCssBaseline: {
+      styleOverrides: {
+        body: {
+          fontSize: '120%', // Match old layout.module.css body font-size: 120%
+        },
+      },
+    },
+  },
   palette: {
     primary: {
       main: '#24818E',


### PR DESCRIPTION
## Summary
- Replace deprecated `gatsby-plugin-gtag` with official `gatsby-plugin-google-gtag`
- Fix body font size regression that occurred during MUI v4→v5 upgrade

## Changes
1. **Google Analytics plugin upgrade**: Switched from the community `gatsby-plugin-gtag` to Gatsby's official `gatsby-plugin-google-gtag` plugin
2. **Font size fix**: Restored 120% body font-size that was accidentally lost during MUI upgrade
   - In MUI v4, `layout.module.css` body styles would override JSS-generated CssBaseline
   - In MUI v5+, Emotion-based CssBaseline overrides CSS modules
   - Solution: Moved font-size to theme.js `MuiCssBaseline` styleOverrides

## Test plan
- [x] Verified Google Analytics tracking still works with new plugin
- [x] Confirmed body font size is back to 120% (19.2px) instead of 16px
- [x] Tested in development mode at localhost:8000

🤖 Generated with [Claude Code](https://claude.com/claude-code)