### PR TITLE
Home page takeover: 5-Year Celebration event

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import { Link } from 'gatsby';
 import Typography from '@mui/material/Typography';
-import Grid from '@mui/material/Grid';
+// import Grid from '@mui/material/Grid';
 import { StaticImage } from 'gatsby-plugin-image';
 import Layout from '../components/layout';
 import ButtondownSignup from '../components/buttondownsignup';
-import IsHr from '../components/is-hr';
-import BlurbPractice from '../components/blurb-practice';
+// import IsHr from '../components/is-hr';
+// import BlurbPractice from '../components/blurb-practice';
 import CenteredColumn from '../components/centered-column';
-import * as GlobalCSS from '../styles/global.module.css';
+// import * as GlobalCSS from '../styles/global.module.css';
 
+/* imageList commented out for 5-year celebration page takeover
 const imageList = [
   {
     image: '/images/logos/second-renaissance.jpg',
@@ -42,6 +43,7 @@ const imageList = [
     comment: 'Co-creating new economic models for livelihoods and co-ops.'
   }
 ];
+*/
 
 
 
@@ -51,92 +53,51 @@ const NamedDefault = ({ data }) => <>
                 style={{ height: '60vh', zIndex: -1, position: 'absolute', 
                         top: '0px', left: '0px', right: '0px'}}
                 imgStyle={{objectFit: 'fill'}}/>
-    <div style={{  minWidth: '350px', maxWidth: '500px', width: 'fit-content', margin: '0 auto', height: '280px' }}>
-      <Typography variant="h2" style={{ color: '#FFFFFF'}}>
-        <p style={{margin:'1vw auto'}}>Intentional Society</p>
+    <div style={{ textAlign: 'center', margin: '0 auto', minHeight: '280px', display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+      <Typography variant="h2" style={{ color: '#FFFFFF', fontSize: 'clamp(2rem, 8vw, 3.75rem)' }}>
+        Intentional Society
       </Typography>
-      <Typography variant="h4" style={{ color: '#FFFFFF'}}>
-        <p style={{margin:'1vw auto 1vw 3vw'}}>being who we want to be</p>
+      <Typography variant="h2" style={{ color: '#FFFFFF', fontSize: 'clamp(2rem, 8vw, 3.75rem)' }}>
+        The 5-Year Celebration
       </Typography>
-      <Typography variant="h4" style={{ color: '#FFFFFF'}}>
-        <p style={{margin:'1vw auto 1vw 3vw'}}>doing what we value</p>
-      </Typography>
-            <Typography variant="h4" style={{ color: '#FFFFFF'}}>
-        <p style={{margin:'1vw auto 1vw 3vw'}}>unfolding the future together</p>
+      <Typography variant="h2" style={{ color: '#FFFFFF', fontSize: 'clamp(2rem, 8vw, 3.75rem)' }}>
+        Launching a New Era
       </Typography>
     </div>
     <CenteredColumn>
       <div style={{fontSize: '1.2em'}}>
 
-          <p>We are a collection of friends devoted to growing ourselves 
-          and our society toward thriving futures. 
-          In these complex and chaotic times, our world 
-          is calling us to become&hellip;</p>
+        <p style={{textAlign: 'center', fontSize: '1.2em'}}>
+          <b>March 15, 2026 &middot; 1:00 PM Pacific &middot; 90 minutes</b>
+        </p>
 
-        <div style={{margin: '0 auto 0 100px', fontSize: '1.5em'}}>
-          <p>&hellip;<b>aware</b> enough to <b>see</b> clearly 👁‍🗨</p>
-          <p>&hellip;<b>spacious</b> enough to <b>face</b> anything 💗</p>
-          <p>&hellip;and <b>wise</b> enough to <b>wield</b> our power 👑</p>
-        </div>
-        <IsHr />
-        <p><i>Being who we want to be</i> is an ever-unfolding process, and we do it by practicing together. 
-          We cultivate a post-conventional culture among us that shifts our seeing, 
-          supports our becoming, and grounds our doing.</p>
-        <p>If you’re looking for the intersection of inner development and systems change, we 
-          invite you to join us in growth and friendship as we
-          practice <i>awareness, acceptance, integrity</i> in a dance of transformation and service to life.</p>
-        <p>See how you can <Link to="/get-involved">get involved</Link>, or 
-          learn more <Link to="/about">about us</Link>.</p>
+        <p>Join us for a landmark gathering as we celebrate five years of Intentional Society!
+          Hear stories from our journey, learn about our evolving programs,
+          and be part of the launch of an expanded network.
+          Plus, we have a significant announcement to share.
+          Whether you've been with us from the start or are just discovering IS,
+          this is the event to attend.</p>
 
-      <IsHr />
-      <p style={{fontSize: '1.2em'}}><Link to="/community">Community</Link> season 20 runs October through December.</p>
+        <p style={{textAlign: 'center'}}>
+          <a href="https://us02web.zoom.us/meeting/register/8nzxXOk5Rzicpmo5mTMwlQ"
+            style={{
+              display: 'inline-block',
+              backgroundColor: '#24818E',
+              color: '#FFFFFF',
+              padding: '12px 32px',
+              borderRadius: '6px',
+              textDecoration: 'none',
+              fontSize: '1.2em',
+              fontWeight: 'bold'
+            }}>
+            Register on Zoom
+          </a>
+        </p>
 
-      <IsHr />
-      <p>Inside Intentional Society (IS), you'll find three spaces.</p>
-      <div style={{ width: 'fit-content', margin: '0 auto'}}>
-      <img src="/images/s17-3spaces.jpg" loading="eager" width="480" alt="three spaces of IS: practice dojo, community hub, intentional ventures"/>
-      </div>
-      <p>The <Link to="/dojo">Practice Dojo</Link> is open to the public for developmental-relational skill-building.</p>
-      <p>Our <Link to="/community">Members Community</Link> is a supportive space of friendship and exploration.</p>
-      <p><Link to="/iv">Intentional Ventures</Link> is pioneering an ecosystem of aligned livelihood.</p>
-      <p>We'd also love to introduce you to our <Link to="/friends">friends</Link> across  
-        the <a href="https://secondrenaissance.net">Second Renaissance</a> movement 
-        and the <a href="https://www.joelightfoot.org/post/the-liminal-web-mapping-an-emergent-subculture-of-sensemakers-meta-theorists-systems-poets">Liminal Web</a> scene.</p>
-      {/*
-      <Grid container spacing={2} justifyContent="center">
-      {imageList.map((item, index) => (
-        <Grid item xs={12} sm={6} md={4} key={index}>
-          <a href={item.link} target="_blank" rel="noopener noreferrer">
-          <img src={item.image} alt={`Image ${index + 1}`} 
-        style={{ 
-          display: "block", 
-          margin: "0 auto", 
-          width: "50%", 
-          height: "auto", 
-          borderRadius: "10px" 
-        }} 
-        onMouseOver={(e) => e.target.style.opacity = "0.5"}
-        onMouseOut={(e) => e.target.style.opacity = "1"} 
-      />
-      </a>
-      <Typography align="center" variant="h6" style={{ marginTop: "10px", fontSize: "1.1rem", fontWeight: "500" }}>
-      {item.comment}
-    </Typography>
-        </Grid>
-      ))}
-    </Grid>
-    */}
-    <IsHr />
-      <p>The collective heart of IS has been beating for over four years now, 
-        with <Link to="/history">more than 200 community sessions</Link> under our belts.</p>
-      <p>Want to follow along with what we're doing and learning? 
-      Subscribe to our Weekly Update newsletter:</p>
-      <ButtondownSignup></ButtondownSignup>
+        <p>Want to follow along with what we're doing and learning?
+          Subscribe to our Weekly Update newsletter:</p>
+        <ButtondownSignup></ButtondownSignup>
 
-      </div>
-
-      <div style={{textAlign: 'right', marginBottom: '-25px'}}>
-        Next page: <Link to="/about">Who We Are</Link>
       </div>
     </CenteredColumn>
   </Layout>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,7 +5,7 @@ import Typography from '@mui/material/Typography';
 import { StaticImage } from 'gatsby-plugin-image';
 import Layout from '../components/layout';
 import ButtondownSignup from '../components/buttondownsignup';
-// import IsHr from '../components/is-hr';
+import IsHr from '../components/is-hr';
 // import BlurbPractice from '../components/blurb-practice';
 import CenteredColumn from '../components/centered-column';
 // import * as GlobalCSS from '../styles/global.module.css';
@@ -71,14 +71,12 @@ const NamedDefault = ({ data }) => <>
           <b>March 15, 2026 &middot; 1:00 PM Pacific &middot; 90 minutes</b>
         </p>
 
-        <p>Join us for a landmark gathering as we celebrate five years of Intentional Society!
-          Hear stories from our journey, learn about our evolving programs,
-          and be part of the launch of an expanded network.
-          Plus, we have a significant announcement to share.
-          Whether you've been with us from the start or are just discovering IS,
-          this is the event to attend.</p>
+        <p>Intentional Society is building a better world from the inside out. We've been meeting
+          for five years now, growing together and expanding our activities. We invite you to
+          celebrate with us, and to join us in launching an expanded relational web that supports
+          more of us in divergent coherence!</p>
 
-        <p style={{textAlign: 'center'}}>
+        <p style={{textAlign: 'center', padding: '12px 0'}}>
           <a href="https://us02web.zoom.us/meeting/register/8nzxXOk5Rzicpmo5mTMwlQ"
             style={{
               display: 'inline-block',
@@ -94,6 +92,42 @@ const NamedDefault = ({ data }) => <>
           </a>
         </p>
 
+        <div style={{fontSize: '0.85em'}}>
+          <p>For the last five years, Intentional Society has been a gathering of friends
+            "being who we want to be" — one which has unfolded from a single weekly video call into a
+            multi-faceted ecosystem of practices, relating, and entrepreneurial spaces. Having firmly
+            rooted our culture in developmental &amp; relational inner exploration, we're now marking an
+            ongoing phase shift: balancing doing and being by integrating outer action.</p>
+          <p>A more beautiful world already exists whenever-and-wherever our biggest selves touch each
+            other's humanity. As we look forward into our next era, we seek to anchor and grow bigger
+            islands of coherence amidst this chaotic and accelerating world. "Be the change" flows from
+            our hearts out into service of a thriving future guided by the question, "Can we humans
+            become wise enough to hold our great power?"</p>
+          <p>Come to hear stories from the history and breadth of Intentional Society, and to celebrate
+            what "awareness, acceptance, integrity" has meant to people over the last half-decade. Come
+            to hear about what we've learned, and about the latest developments of our relational and
+            entrepreneurial programs. Come for the literal million-dollar announcement, and to
+            collaborate in launching an expanding relational web.</p>
+          <p>We invite you to join us on March 15th to celebrate and to connect with this part of the
+            greater whole we're already becoming.</p>
+        </div>
+        <p style={{textAlign: 'center', padding: '12px 0'}}>
+          <a href="https://us02web.zoom.us/meeting/register/8nzxXOk5Rzicpmo5mTMwlQ"
+            style={{
+              display: 'inline-block',
+              backgroundColor: '#24818E',
+              color: '#FFFFFF',
+              padding: '12px 32px',
+              borderRadius: '6px',
+              textDecoration: 'none',
+              fontSize: '1.2em',
+              fontWeight: 'bold'
+            }}>
+            Register on Zoom
+          </a>
+        </p>
+        <br /><br />
+        <IsHr />
         <p>Want to follow along with what we're doing and learning?
           Subscribe to our Weekly Update newsletter:</p>
         <ButtondownSignup></ButtondownSignup>


### PR DESCRIPTION
## Summary

- Replaces the home page content with a promotional page for "The 5-Year Celebration: Launching a New Era" (March 15, 2026, 1:00 PM Pacific)
- Hero shows three centered, responsive h2 lines over the existing teal background
- Body includes date/time, teaser paragraph, two Register on Zoom CTAs, longer context section, and newsletter signup
- Unused imports commented out (not deleted) for easy restoration after the event

## Test plan

- [x] Visit home page on desktop — hero text and button display correctly
- [x] Visit home page on mobile — hero text scales down without wrapping
- [x] Confirm "Register on Zoom" links open the correct Zoom registration URL
- [x] Confirm newsletter signup still functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)