### PR TITLE
Add /web page content and unify heading styles

### DIFF
--- a/src/components/is-appbar.js
+++ b/src/components/is-appbar.js
@@ -35,7 +35,7 @@ const NamedDefault = () => {
       }}
     >
       <Toolbar>
-        <Typography variant="h5" sx={{ flexGrow: 1, color: 'inherit' }}>
+        <Typography variant="h4" sx={{ flexGrow: 1, color: 'inherit' }}>
           <Link to="/" className={GlobalCSS.nostyleLink}>
             Intentional Society
           </Link>

--- a/src/components/is-appbar.js
+++ b/src/components/is-appbar.js
@@ -35,11 +35,11 @@ const NamedDefault = () => {
       }}
     >
       <Toolbar>
-        <Typography variant="h4" sx={{ flexGrow: 1, color: 'inherit' }}>
+        <div className={GlobalCSS.appbarWordmark} style={{ flexGrow: 1, color: 'inherit' }}>
           <Link to="/" className={GlobalCSS.nostyleLink}>
             Intentional Society
           </Link>
-        </Typography>
+        </div>
         <Button
           component={Link}
           to="/about"

--- a/src/gatsby-theme-material-ui-top-layout/theme.js
+++ b/src/gatsby-theme-material-ui-top-layout/theme.js
@@ -44,7 +44,7 @@ const theme = createTheme({
       fontWeight: 400,
       lineHeight: 1.334,
       letterSpacing: '0em',
-      marginTop: '20px',
+      marginTop: '10px',
       marginBottom: '10px',
     },
     h5: {
@@ -53,7 +53,7 @@ const theme = createTheme({
       fontWeight: 500,
       lineHeight: 1.6,
       letterSpacing: '0.0075em',
-      marginTop: '20px',
+      marginTop: '10px',
       marginBottom: '10px',
     },
     h6: {
@@ -62,7 +62,7 @@ const theme = createTheme({
       fontWeight: 500,
       lineHeight: 1.6,
       letterSpacing: '0.0075em',
-      marginTop: '20px',
+      marginTop: '10px',
       marginBottom: '10px',
     },
   },

--- a/src/gatsby-theme-material-ui-top-layout/theme.js
+++ b/src/gatsby-theme-material-ui-top-layout/theme.js
@@ -10,21 +10,76 @@ const theme = createTheme({
   typography: {
     // Default body font is Ovo (serif)
     fontFamily: ovoFont,
-    // Headings use Gudea (sans-serif)
-    h1: { fontFamily: gudeaFont },
-    h2: { fontFamily: gudeaFont },
-    h3: { fontFamily: gudeaFont },
-    h4: { fontFamily: gudeaFont },
-    h5: { fontFamily: gudeaFont },
-    h6: { fontFamily: gudeaFont },
+    // Headings use Gudea (sans-serif) with explicit sizing
+    h1: {
+      fontFamily: gudeaFont,
+      fontSize: '5rem',
+      fontWeight: 300,
+      lineHeight: 1.167,
+      letterSpacing: '-0.01562em',
+      marginTop: '20px',
+      marginBottom: '20px',
+    },
+    h2: {
+      fontFamily: gudeaFont,
+      fontSize: '3rem',
+      fontWeight: 400,
+      lineHeight: 1.167,
+      letterSpacing: '0em',
+      marginTop: '20px',
+      marginBottom: '20px',
+    },
+    h3: {
+      fontFamily: gudeaFont,
+      fontSize: '2.125rem',
+      fontWeight: 400,
+      lineHeight: 1.235,
+      letterSpacing: '0.00735em',
+      marginTop: '20px',
+      marginBottom: '20px',
+    },
+    h4: {
+      fontFamily: gudeaFont,
+      fontSize: '1.5rem',
+      fontWeight: 400,
+      lineHeight: 1.334,
+      letterSpacing: '0em',
+      marginTop: '20px',
+      marginBottom: '10px',
+    },
+    h5: {
+      fontFamily: gudeaFont,
+      fontSize: '1.25rem',
+      fontWeight: 500,
+      lineHeight: 1.6,
+      letterSpacing: '0.0075em',
+      marginTop: '20px',
+      marginBottom: '10px',
+    },
+    h6: {
+      fontFamily: gudeaFont,
+      fontSize: '1rem',
+      fontWeight: 500,
+      lineHeight: 1.6,
+      letterSpacing: '0.0075em',
+      marginTop: '20px',
+      marginBottom: '10px',
+    },
   },
   components: {
     MuiCssBaseline: {
-      styleOverrides: {
+      styleOverrides: (themeParam) => ({
         body: {
           fontSize: '120%', // Match old layout.module.css body font-size: 120%
         },
-      },
+        // Apply theme heading styles to raw HTML elements (for markdown content)
+        h1: themeParam.typography.h1,
+        h2: themeParam.typography.h2,
+        h3: themeParam.typography.h3,
+        h4: themeParam.typography.h4,
+        h5: themeParam.typography.h5,
+        h6: themeParam.typography.h6,
+      }),
     },
   },
   palette: {

--- a/src/md/developmental-practice-series.md
+++ b/src/md/developmental-practice-series.md
@@ -4,7 +4,7 @@
   style="width: 100%; margin-bottom: 30px;"
 />
 
-### IS Developmental Practice Series
+## IS Developmental Practice Series
 
 Skillful relating to inner and outer challenges. Liberation from stuckness and not-okay-ness. Spacious ease and equanimity. These are learnable skills, freely available through interactive, relational, intentional practice in a supportive environment.
 
@@ -23,21 +23,21 @@ In plain words, we're building a bridge to "being who we want to be" beyond what
 
 ---
 
-#### 🗓️Schedule and Practices
+### 🗓️Schedule and Practices
 
-##### Unit 1 (Awareness) July 10, July 17, July 24:
+#### Unit 1 (Awareness) July 10, July 17, July 24:
 
 - **Empathy Circle** – receptive listening and reflection
 - **Parts Work (IFS)** – listening to and being with parts-of-self
 - **Interpersonal Gap** – perspectival awareness and frame hygiene
 
-##### Unit 2 (Acceptance) July 31, Aug 7, Aug 14:
+#### Unit 2 (Acceptance) July 31, Aug 7, Aug 14:
 
 - **T-Group** – noticing and naming our experiences
 - **Circling** – welcoming everything in connection
 - **Inquiry Spiraling** – perspective weaving, collective dreaming
 
-##### Unit 3 (Integrity) Aug 21, Aug 28, Sept 4:
+#### Unit 3 (Integrity) Aug 21, Aug 28, Sept 4:
 
 - **Nine Whys** – (re)connecting to desire, motivations, and purpose
 - **Pure coaching + Clean language** – clean (space-holding, not self-injecting) coaching basics
@@ -49,7 +49,7 @@ After signing up, you'll receive a recurring calendar invite for all sessions. T
 
 ---
 
-#### Reflections from 2024 participants
+### Reflections from 2024 participants
 
 <div style="display: flex; gap: 20px; margin-bottom: 30px; flex-wrap: wrap; justify-content: center;">
   <img
@@ -80,7 +80,7 @@ After signing up, you'll receive a recurring calendar invite for all sessions. T
 
 ---
 
-#### About the facilitator
+### About the facilitator
 
 <div style="display: flex; align-items: center; gap: 20px; flex-wrap: wrap; justify-content: center;">
   <img

--- a/src/md/thecall.md
+++ b/src/md/thecall.md
@@ -1,12 +1,12 @@
 Hi there. 👋 I'm James of December 2020, and this is my story of how we could grow bigger than our problems. Which problems? Well, I see three types:
 
-### Societal
+## Societal
 Our crumbling political norms and our abysmal epidemic response (in the USA context) have shown how little capability we have for large-scale coordination or sensemaking. We are gripped in culture war power struggle and no one in power has any possible way out. Existential threats loom in front of our society: inequity, authoritarianism, climate change, and the relentless progress of greater AI, nano-, bio-, and other technological power becoming more widely accessible.
 
-### Relational
+## Relational
 Our connections to physical tribes are gone or gutted. Our church and traditional community connections are waning. We have fewer deep friendships, scattered more widely. Our relationships are strained and stressed by this social media age of algorithmically intermediated digital (dis-)connection and physical isolation. We crave belonging, connection, safety, and love.
 
-### Personal
+## Personal
 We spend our lives in the pursuit of happiness, and find it elusive. Traumas large and small haunt us as we navigate adulting in a complex and rapidly changing world. The scripts of prior generations don't work for newer ones. We strive to fit in, to find ourselves, and to find meaning and purpose in our lives. Then that's all overwhelming so we cope by bingewatching shows while doomscrolling on our phones.
 
 Yikes, right? This whole complex system of you, I, we, and society must adapt by developing the capacity and capability to survive and thrive at every level. But what can people do? I am one person. I am a part of that system. So are you. None of us can beat the system. There is no conventional solution. Faced with that, most people avert their eyes and turn back to doing whatever makes sense in their conventional social frame.
@@ -18,13 +18,13 @@ So, what of a solution? Why did I say "grow bigger?" I'll claim that more capabl
 
 Together they bring us the capacity to become our biggest selves and the capability to move through increasing complexity. This happens within our own selves, takes root in our relationships, and can then flow outward to grow a new system that can succeed the old one:
 
-### Personal
+## Personal
 I've discovered some of this through my own experience - when my conventional modern self-authored identity failed, pulling me to find another way to grow. I've found that "growing up" connects to spaces much bigger than typical modern adulthood. Bigger perspective, smaller ego, fewer constraints. Self-awareness, introspection, integration. This path seems to converge both with the latest scientific psychology and with the experiential knowing that mystics have pointed to for centuries.
 
-### Relational
+## Relational
 A bigger, better mode of being is possible when we embody these practices and let go our attachments. But this is no easy task! It is a developmental journey, unique to each person and yet shared across all humanity. We can't reliably do it on our own - we travel farther and faster when securely supported by trusted companions. We can borrow each others' eyes to see ourselves from other perspectives of compassion and insight. Plus, time spent in rich connection and friendship is deeply nourishing and generative!
 
-### Societal
+## Societal
 Development into a bigger stance results in increased capacity, greater awareness, higher agency, bigger perspective, meaningful contribution, and deeper peace. Group practices and norms support people stepping into these capabilities. If we can support this upgraded "cultural code" in larger community contexts as we expand, we'll be positioned to help support our _society_ in being what _it_ wants to be, expanding its ability to meet its global-scale challenges.
 
 Does this resonate with you? I'm looking for allies right now: explorers and pioneers of co-creation as we seek to develop a kernel of inter-subjective practices supporting our growth in awareness and intentionality. Particularly, but not exclusively, if you're experienced in or enthusiastic about any of these areas:

--- a/src/md/web.md
+++ b/src/md/web.md
@@ -1,0 +1,48 @@
+## Join the relational web
+
+This is a web of *trust* and *collaboration*.
+
+Intentional Society, expressed as a relational web of humans — a network, a distributed village, an ecosystem of people and care.
+
+What is it that coheres this web of human relationships? Inner development, wise action, human connection. This web is for those who value:
+
+- **Inner development:** We are those who practice awareness, acceptance, and integrity in growing toward being who we want to be.
+- **Wise action:** We are those whose lives form a living vow in service of what is good, true, and beautiful, integrated from personal to planetary.
+- **Human connection:** We are connected to, and caring for, these particular humans in this web, an island of coherence and support.
+
+…particular humans? Yes, joining a web of relationships requires a referral from one existing member. If you have no connection to IS folks, come meet some at a Connection Call. We're happy to continue diversifying our web and/or to introduce you to our friends.
+
+The evolution of this web is and will follow what's already emerging in our relational field. Around us in "liminal" space are other communities and entities with similar worldviews and principles, and reifying our web internally will enable us to cohere in the field externally as an organizational actor exploring coalition and alliance.
+
+We are a part of a developmental collaborative culture of coordination spanning the globe — and this is our small village, our collection of friends, in which we embody this culture in everyday life.
+
+### What's inside the web?
+
+#### Quarterly Convening
+
+Once a quarter, we gather the whole network for a full assembly. Every member contributes a "what's alive?" update, crews are coordinated, strategies are revisited. It's a party and a catalyst.
+
+#### Web Directory + Relational Mapping
+
+It's important that we can see each other and how we're connected. First, standard profiles and contact info go in a conventional directory. The relational layer will then roll out with a node-link diagram mapping our trust relationships.
+
+#### Relational Programs
+
+- **The Gumball Machine** - pull a lever and get matched with someone you don't know for an intro call!
+- **Presence Pods** - Four people, four calls, each person one turn to receive the empathic Circling-y curiosity empathetic reflection of the group.
+- **Casework Pods** - Four people, four calls, each person one turn to receive the empathic Circling-y curiosity empathetic reflection of the group.
+- **Thematic Crews** - Self-organized interest groups
+
+#### Weekly Community Calls
+
+Running for 5+ years as the heartbeat of IS, community members (self-defined, open within the web) gather each Sunday for developmental-relational practices and explorations. Growth, belonging, companionship, solidarity, all rooted in "being who we want to be". More info here.
+
+#### (Future) Mesh Access
+
+We dream of partnering with other aligned networks/communities/orgs to map our connections and navigate trust ramps into coordination, coalition, and alliance toward greater meaning and impact emerging across the field.
+
+### Requirements
+
+Membership is lightweight and non-exclusive - we encourage you to belong to other webs of mutual support both physically and virtually. But it does consist of intentionality - to grow your own perspective, to be in service to something greater than yourself, and to be in relationship with others as catalyst to both inner and outer change.
+
+Minimum activity expectations consist of a couple hours quarterly "for" the web: imagine 90 minutes presence and listening, 20 minutes clicking/updating, 10 minutes writing/sourcing. This can be satisfied by the quarterly convening and communication activities that form a seasonal rhythm for our full system. In smaller scopes, our congregations and crews have more frequent rhythms that fit a variety of depths.

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -11,7 +11,7 @@ const NamedDefault = () => (
     <div style={{ height: '5vh' }}></div>
     <CenteredColumn>
       {/* Section: Who We Are */}
-      <Typography variant="h4">Who We Are</Typography>
+      <Typography variant="h3">Who We Are</Typography>
       <img
         src="/images/wave-to-internet.png"
         alt="Us waving to the internet"
@@ -45,7 +45,7 @@ const NamedDefault = () => (
 
       <IsHr />
       <a className={GlobalCSS.anchorOffset} id="membership"></a>
-      <Typography variant="h4">Regarding Membership</Typography>
+      <Typography variant="h3">Regarding Membership</Typography>
 
       <p>Who and what makes a good "fit" within Intentional Society? The cornerstone of our culture
         is first and foremost a desire to grow. It also takes an attitude of openness, 
@@ -80,7 +80,7 @@ const NamedDefault = () => (
       <IsHr />
 
       {/* Section: What We Do */}
-      <Typography variant="h4">What We Do</Typography>
+      <Typography variant="h3">What We Do</Typography>
       <p>On the surface, the simple story is that we talk with each another on video calls.
         Most of these take the form of our publicly-accessible <b>practice program</b>. 
         These practice sessions are facilitated, structured calls that run 90 minutes 
@@ -100,7 +100,7 @@ const NamedDefault = () => (
       </p>
 
       <IsHr />
-      <Typography variant="h5">Deliberately Developmental details for geeks</Typography>
+      <Typography variant="h4">Deliberately Developmental details for geeks</Typography>
 
       <p>At the deeper conceptual layer, what we're doing together is <b>authoring a developmental 
         community of practice with a culture of expanded awareness</b>. There's a conventional script 

--- a/src/pages/dojo.js
+++ b/src/pages/dojo.js
@@ -29,11 +29,11 @@ const NamedDefault = ({ data }) => (
         </ul></p>
       {/*
        <IsHr />
-       <Typography variant="h5">What's happening now</Typography>
+       <Typography variant="h4">What's happening now</Typography>
        <p><BlurbPractice /></p>
         */}
       <IsHr />
-      <Typography variant="h5">History</Typography>
+      <Typography variant="h4">History</Typography>
  
       <p>The Practice Dojo became its own space in 2024 with the debut of the IS <Link to="/developmental-practice-series">
       Developmental Practice Series</Link>, followed by an Exploratory Practice Series tour and the
@@ -46,7 +46,7 @@ const NamedDefault = ({ data }) => (
       </p>
 
       <IsHr />
-      <Typography variant="h5">Further geekery</Typography>
+      <Typography variant="h4">Further geekery</Typography>
       <p>Why dojo? The "<a href="https://en.wikipedia.org/wiki/Dojo">dojo</a>" metaphor helps transmit 
         the nature of this practice space: 
         it is a programmatic facilitated space of immersive experiential learning and transformative growth. 

--- a/src/pages/friends.js
+++ b/src/pages/friends.js
@@ -140,14 +140,14 @@ const FriendsPage = () => (
   <Layout>
     <div style={{ height: '5vh' }}></div>
     <CenteredColumn>
-      <Typography variant="h3">Friends of Intentional Society</Typography>
+      <Typography variant="h2">Friends of Intentional Society</Typography>
       <div style={{ height: '1px', backgroundColor: '#ccc', width: '100%', margin: '10px 0' }}></div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
         {friendsList.sort((a,b)=>a.name.localeCompare(b.name)).map((friend, index) => (
           <div key={index} style={{ display: 'flex', alignItems: 'center', gap: '15px' }}>
             <img src={friend.image} alt={friend.name} style={{ width: '100px', height: '100px', borderRadius: '50%' }} />
             <div>
-              <Typography variant="h5">
+              <Typography variant="h4">
                 <a href={friend.website} target="_blank" rel="noopener noreferrer">{friend.name}</a>
               </Typography>
               <p dangerouslySetInnerHTML={{ __html: friend.description }} />

--- a/src/pages/get-involved.js
+++ b/src/pages/get-involved.js
@@ -13,11 +13,11 @@ const NamedDefault = ({ data }) => {
     <Layout>
       <div style={{ height: '5vh' }}></div>
       <CenteredColumn>
-        <Typography variant="h3">Get Involved</Typography>
+        <Typography variant="h2">Get Involved</Typography>
         <p> </p>
 
         <a className={GlobalCSS.anchorOffset} id="connection-calls"></a>
-        <Typography variant="h4">Connection Calls</Typography>
+        <Typography variant="h3">Connection Calls</Typography>
         <p>Want to learn about Intentional Society, its history, values, and core practices?
            Want to connect with one-or-more people of IS? This is a great entry point for new folks,
            and can also satisfy the personal-connection prerequisite for community membership.
@@ -26,7 +26,7 @@ const NamedDefault = ({ data }) => {
         <p><BlurbOfficeHours /> Bring your video camera (phone is okay), microphone, and
           any <Link to="/questions">questions</Link> you might have.</p>
 
-        <Typography variant="h4">Relational Dojo</Typography>
+        <Typography variant="h3">Relational Dojo</Typography>
         <p>Relational practices are how we help ourselves grow. Our "Practice Dojo" is in the process of 
           merging into Relational Dojo, a larger community and platform for relational practices.
           <a 
@@ -35,14 +35,14 @@ const NamedDefault = ({ data }) => {
         practices</a>, and the website will be up shortly.
         </p>
 
-        <Typography variant="h4">Community Membership</Typography>
+        <Typography variant="h3">Community Membership</Typography>
         <p>Join the <Link to="/community">Community</Link> for Sunday Hub calls and more.</p>
 
-        <Typography variant="h3">Information streams</Typography>
+        <Typography variant="h2">Information streams</Typography>
         <p> </p>
 
         <a className={GlobalCSS.anchorOffset} id="newsletter"></a>
-        <Typography variant="h4">Weekly Updates Newsletter</Typography>
+        <Typography variant="h3">Weekly Updates Newsletter</Typography>
         <p>Stay informed with this public weekly newsletter about what we're doing and learning.
           Once a week (usually Thursday) you'll receive a short update
           sharing about our recent learning and what's coming up soon.
@@ -54,7 +54,7 @@ const NamedDefault = ({ data }) => {
         <ButtondownSignup/>
         <p>Then, don't forget to go click on the confirmation email! You won't be subscribed if you don't.</p>
 
-        <Typography variant="h4">Twitter</Typography>
+        <Typography variant="h3">Twitter</Typography>
         <p>Follow <a href="https://twitter.com/IntentionalSoc">@IntentionalSoc</a> on
           Twitter if that's your thing. Shares some newsletter content,
           occasional announcements, not much of a nag/reminder stream. Also a handy

--- a/src/pages/history.js
+++ b/src/pages/history.js
@@ -362,7 +362,7 @@ const HistoryPage = () => (
   <Layout>
     <div style={{ height: '5vh' }}></div>
     <CenteredColumn>
-      <Typography variant="h3">History</Typography>
+      <Typography variant="h2">History</Typography>
       <p>
         Hi, James here. I'm the founder/
         <a href="https://workwithsource.com/what-is-source/how-initiatives-start/">source</a>/
@@ -377,13 +377,13 @@ const HistoryPage = () => (
       </p>
       <p>What followed has been a patient unfolding with many stories embedded in the journey. 
         Below you can find title-based records of weekly sessions going all the way back to the beginning.</p>
-      <Typography variant="h4">Historical Event Log</Typography>
+      <Typography variant="h3">Historical Event Log</Typography>
       <Grid container spacing={1} direction="column" style={{ maxWidth: '800px', margin: '0 auto' }}>
       {seasons.map((season, index) => (
         <Grid item xs={12} sm={12} md={12} lg={12} key={index} style={{ paddingBottom: '8px' }}>
         <Accordion>
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h5">{season.title}</Typography>
+                <Typography variant="h4">{season.title}</Typography>
                 </AccordionSummary>
               <AccordionDetails>
                 <div style={{ width: '100%' }}>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -54,13 +54,13 @@ const NamedDefault = ({ data }) => <>
                         top: '0px', left: '0px', right: '0px'}}
                 imgStyle={{objectFit: 'fill'}}/>
     <div style={{ textAlign: 'center', margin: '0 auto', minHeight: '280px', display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
-      <Typography variant="h2" style={{ color: '#FFFFFF', fontSize: 'clamp(2rem, 8vw, 3.75rem)' }}>
+      <Typography variant="h2" style={{ color: '#FFFFFF', fontSize: 'clamp(2rem, 8vw, 3.75rem)', margin: 0 }}>
         Intentional Society
       </Typography>
-      <Typography variant="h2" style={{ color: '#FFFFFF', fontSize: 'clamp(2rem, 8vw, 3.75rem)' }}>
+      <Typography variant="h2" style={{ color: '#FFFFFF', fontSize: 'clamp(2rem, 8vw, 3.75rem)', margin: 0 }}>
         The 5-Year Celebration
       </Typography>
-      <Typography variant="h2" style={{ color: '#FFFFFF', fontSize: 'clamp(2rem, 8vw, 3.75rem)' }}>
+      <Typography variant="h2" style={{ color: '#FFFFFF', fontSize: 'clamp(2rem, 8vw, 3.75rem)', margin: 0 }}>
         Launching a New Era
       </Typography>
     </div>

--- a/src/pages/iv.js
+++ b/src/pages/iv.js
@@ -27,7 +27,7 @@ const NamedDefault = ({ data }) => (
       <p>IV's heartbeat calls happen Fridays at 9am Pacific / Noon Eastern.</p>
       
       <IsHr />
-      <Typography variant="h5">The story so far</Typography>
+      <Typography variant="h4">The story so far</Typography>
       <p>Intentional Ventures began April 2024 with a founding team of about a dozen.</p>
 
       <p>After three quarters with its founding team, at the end of 2024 IV had experimentally generated revenue, established 

--- a/src/pages/orientation.js
+++ b/src/pages/orientation.js
@@ -28,7 +28,7 @@ const NamedDefault = ({ data }) => {
     <Layout>
       <div style={{ height: '5vh' }}></div>
       <CenteredColumn>
-        <Typography variant="h3" style={{ textAlign: 'center', marginBottom: '20px' }}>Orientation</Typography>
+        <Typography variant="h2" style={{ textAlign: 'center', marginBottom: '20px' }}>Orientation</Typography>
 
         {/* Image Carousel */}
         <div style={{ marginBottom: '40px', textAlign: 'center', position: 'relative' }}>

--- a/src/pages/questions.js
+++ b/src/pages/questions.js
@@ -104,7 +104,7 @@ const NamedDefault = ({ data }) => {
     <div style={{ height: '5vh' }}></div>
     <CenteredColumn>
       <p>TODO: This still needs a 2025 refresh!</p>
-      <Typography variant="h3">Common Questions</Typography>
+      <Typography variant="h2">Common Questions</Typography>
       {qas.map((qa) => <>
         <h4>Q: {qa[0]}</h4>
         <p>A: {qa[1]}</p>

--- a/src/pages/resources.js
+++ b/src/pages/resources.js
@@ -9,7 +9,7 @@ const NamedDefault = ({ data }) => (
   <Layout>
     <div style={{ height: '5vh' }}></div>
     <CenteredColumn>
-      <Typography variant="h3">Resources</Typography>
+      <Typography variant="h2">Resources</Typography>
       <p>Jump to:</p>
       <ul>
         <li><Link to="#relational-practices">Relational Practices List</Link></li>
@@ -21,10 +21,10 @@ const NamedDefault = ({ data }) => (
         <li><Link to="/friends">Friends of Intentional Society</Link></li>
       </ul>
       <a className={GlobalCSS.anchorOffset} id="relational-practices"></a>
-      <Typography variant="h4">Relational Practices List</Typography>
+      <Typography variant="h3">Relational Practices List</Typography>
       <p>We have tried and enjoyed the following practices:</p>
       <a className={GlobalCSS.anchorOffset} id="empathy-circling"></a>
-      <Typography variant="h5">Empathy Circling</Typography>
+      <Typography variant="h4">Empathy Circling</Typography>
       <ul>
         <li>This practice is, very simply, listening to someone and reflecting back their thoughts. 
           The sweet spot is a balance of maintaining accuracy and fidelity to their original expression 
@@ -36,7 +36,7 @@ const NamedDefault = ({ data }) => (
           Our experience report</a></li>
       </ul>
       <a className={GlobalCSS.anchorOffset} id="authentic-relating"></a>
-      <Typography variant="h5">Authentic Relating</Typography>
+      <Typography variant="h4">Authentic Relating</Typography>
       <ul>
         <li>This is a large collection of games/practices, best represented by the manual assembled 
           by Sara Ness. We've used the Noticing game, Hotseat, and others 
@@ -49,7 +49,7 @@ const NamedDefault = ({ data }) => (
           Our experience report</a></li>
       </ul>
       <a className={GlobalCSS.anchorOffset} id="circling"></a>
-      <Typography variant="h5">Circling</Typography>
+      <Typography variant="h4">Circling</Typography>
       <ul>
         <li>Circling is a present-moment practice of noticing our sensations in relationship with one another
           and being curious about another's experience. It has grown rather popular and 
@@ -61,7 +61,7 @@ const NamedDefault = ({ data }) => (
           Our experience report</a></li>
       </ul>
       <a className={GlobalCSS.anchorOffset} id="collective-presencing"></a>
-      <Typography variant="h5">Collective Presencing</Typography>
+      <Typography variant="h4">Collective Presencing</Typography>
       <ul>
         <li>A circle practice of group sense-making, developed by Ria Baeck. Exploring the space of 
           a preselected open question, participants bring their observations “to the center” of the 
@@ -73,7 +73,7 @@ const NamedDefault = ({ data }) => (
           Our experience report</a></li>
       </ul>
       <a className={GlobalCSS.anchorOffset} id="inquiry-spiraling"></a>
-      <Typography variant="h5">Inquiry Spiraling</Typography>
+      <Typography variant="h4">Inquiry Spiraling</Typography>
       <ul>
         <li>Closely related to Collective Presencing, this practice circles around exploring the 
           question space itself, weaving together a simultaneous mix of diverging and converging questions 
@@ -85,7 +85,7 @@ const NamedDefault = ({ data }) => (
           Our experience report</a></li>
       </ul>
       <a className={GlobalCSS.anchorOffset} id="case-work"></a>
-      <Typography variant="h5">Case Work</Typography>
+      <Typography variant="h4">Case Work</Typography>
       <ul>
         <li>By case work, we mean the examination of developmental challenges that are working us. A case giver 
           shares the story of their situation, and is supported by a small group in taking perspective on that 
@@ -98,7 +98,7 @@ const NamedDefault = ({ data }) => (
           Our experience report</a></li>
       </ul>
       <a className={GlobalCSS.anchorOffset} id="peer-coaching"></a>
-      <Typography variant="h5">Peer Coaching</Typography>
+      <Typography variant="h4">Peer Coaching</Typography>
       <ul>
         <li>Taken as a general concept, this practice is “pure” coaching, defined by the stance that 
           the coachee already holds in themselves everything that's necessary to resolve their own challenge(s). 
@@ -111,7 +111,7 @@ const NamedDefault = ({ data }) => (
           Our experience report</a></li>
       </ul>
       <a className={GlobalCSS.anchorOffset} id="t-group"></a>
-      <Typography variant="h5">T-group</Typography>
+      <Typography variant="h4">T-group</Typography>
       <ul>
         <li>Adopted via our friends 
           at <a href="https://www.startercultures.us/creative-offerings/communication-dojo">Communication Dojo</a>, 
@@ -124,7 +124,7 @@ const NamedDefault = ({ data }) => (
           Our experience report</a></li>
       </ul>
       <a className={GlobalCSS.anchorOffset} id="glass-bead-game"></a>
-      <Typography variant="h5">Glass Bead Game</Typography>
+      <Typography variant="h4">Glass Bead Game</Typography>
       <ul>
         <li>Inspired by <a href="https://en.wikipedia.org/wiki/The_Glass_Bead_Game">a novel</a>, this is a 
         (usually) two-player game in which players take turns riffing off a concept and each other in a 
@@ -134,7 +134,7 @@ const NamedDefault = ({ data }) => (
           Our experience report</a></li>
       </ul>
       <a className={GlobalCSS.anchorOffset} id="agile-retrospectives"></a>
-      <Typography variant="h5">Agile Retrospectives</Typography>
+      <Typography variant="h4">Agile Retrospectives</Typography>
       <ul>
         <li>Widespread in agile software development and elsewhere, literally “learning from looking 
           back” as a group. This can take many forms, from simple rubrics like “start stop continue” 
@@ -145,7 +145,7 @@ const NamedDefault = ({ data }) => (
         <li><a href="https://pragprog.com/titles/dlret/agile-retrospectives/">Book by Esther Derby and Diana Larsen</a></li>
       </ul>
       <a className={GlobalCSS.anchorOffset} id="ifs"></a>
-      <Typography variant="h5">Internal Family Systems (IFS)</Typography>
+      <Typography variant="h4">Internal Family Systems (IFS)</Typography>
       <ul>
         <li>
           Internal Family Systems (commonly abbreviated as IFS) is a (self-)theraputic model that 
@@ -161,7 +161,7 @@ const NamedDefault = ({ data }) => (
         </li>
       </ul>
       <a className={GlobalCSS.anchorOffset} id="media"></a>
-      <Typography variant="h4">Media Appearances</Typography>
+      <Typography variant="h3">Media Appearances</Typography>
       <ul>
         <li><a href="https://www.youtube.com/watch?v=gVx8mAzcMDA">How to Handle 
         Anything</a> w/ <a href="https://lifeitself.org/blog/how-to-handle-anything-in-life-and-community">Life 

--- a/src/pages/web.js
+++ b/src/pages/web.js
@@ -1,33 +1,29 @@
 import React from 'react';
-import { Link } from 'gatsby';
-import Typography from '@mui/material/Typography';
+import { graphql } from 'gatsby';
 import Layout from '../components/layout';
 import CenteredColumn from '../components/centered-column';
+import * as MarkdownStyles from '../styles/markdown-content.module.css';
 
 const NamedDefault = ({ data }) => (
   <Layout>
     <div style={{ height: '5vh' }}></div>
     <CenteredColumn>
-      <Typography variant="h2">The Relational Web</Typography>
-
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt
-        ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
-        ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-
-      <Typography variant="h3">Lorem Ipsum</Typography>
-      <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-        nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
-        deserunt mollit anim id est laborum.</p>
-
-      <Typography variant="h3">Lorem Ipsum</Typography>
-      <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque
-        laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi
-        architecto beatae vitae dicta sunt explicabo.</p>
-
-      <div style={{textAlign: 'right', marginBottom: '-25px'}}>
-        <Link to="/">Back to home page</Link>
-      </div>
+      <div
+        className={MarkdownStyles.markdownContent}
+        dangerouslySetInnerHTML={{__html: data.content.childMarkdownRemark.html}}
+      />
     </CenteredColumn>
   </Layout>
 );
+
 export default NamedDefault;
+
+export const query = graphql`
+  query {
+    content: file(relativePath: { eq: "md/web.md" }) {
+      childMarkdownRemark {
+        html
+      }
+    }
+  }
+`;

--- a/src/styles/global.module.css
+++ b/src/styles/global.module.css
@@ -25,6 +25,14 @@ blockquote {
   background-color: #ecf4fa;
 }
 
+.appbar-wordmark {
+  font-family: Gudea, Helvetica, Arial, sans-serif;
+  font-size: 1.5rem;
+  font-weight: 400;
+  line-height: 1.334;
+  margin: 0;
+}
+
 .nostyle-link, .nostyle-link:focus, .nostyle-link:focus:hover,
 .nostyle-link:focus:visited, .nostyle-link:focus:link, .nostyle-link:focus:active {
   color: inherit;

--- a/src/styles/markdown-content.module.css
+++ b/src/styles/markdown-content.module.css
@@ -1,36 +1,5 @@
-/* Styles for markdown-rendered content to match Material-UI Typography */
-
-.markdownContent h3 {
-  font-size: 3rem;
-  font-weight: 400;
-  line-height: 1.167;
-  letter-spacing: 0em;
-  margin-bottom: 20px;
-  margin-top: 0;
-}
-
-.markdownContent h4 {
-  font-size: 2.125rem;
-  font-weight: 400;
-  line-height: 1.235;
-  letter-spacing: 0.00735em;
-  margin-bottom: 20px;
-  margin-top: 0;
-}
-
-.markdownContent h5 {
-  font-size: 1.5rem;
-  font-weight: 400;
-  line-height: 1.334;
-  letter-spacing: 0em;
-  margin-bottom: 10px;
-  margin-top: 20px;
-}
-
-/* First h5 after h4 shouldn't have top margin */
-.markdownContent h4 + h5 {
-  margin-top: 0;
-}
+/* Styles for markdown-rendered content */
+/* Heading styles are now defined globally via MUI theme (theme.js) */
 
 /* Style hr using shared IsHr variables from global.module.css */
 .markdownContent hr {


### PR DESCRIPTION
## Summary
- Add `/web` page with relational web content (values, programs, requirements) rendered from markdown source (`src/md/web.md`)
- Unify heading styles site-wide: define all heading sizes/margins once in `theme.js` typography config, applied to both MUI Typography components and raw HTML elements (via CssBaseline) — removing duplicate styles from markdown CSS
- Standardize heading levels across all pages: h2 for page titles, h3 for sections, h4 for sub-sections (shifted from h3/h4/h5)

## Test plan
- [x] Verify `/web` page renders correctly with proper heading sizes and markdown formatting
- [x] Spot-check existing pages (about, get-involved, history, resources, community) for correct heading appearance
- [x] Verify markdown pages (developmental-practice-series, thecall) render with correct heading sizes
- [x] Check appbar site name still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)