### PR TITLE
Bump h2 page title size to 3.5rem

### DIFF
--- a/src/gatsby-theme-material-ui-top-layout/theme.js
+++ b/src/gatsby-theme-material-ui-top-layout/theme.js
@@ -22,7 +22,7 @@ const theme = createTheme({
     },
     h2: {
       fontFamily: gudeaFont,
-      fontSize: '3rem',
+      fontSize: '3.5rem',
       fontWeight: 400,
       lineHeight: 1.167,
       letterSpacing: '0em',


### PR DESCRIPTION
## Summary
- Increase h2 font size from 3rem to 3.5rem to restore page title prominence after heading scale unification in #23

## Test plan
- [ ] Check page titles (e.g. dojo, community, get-involved) look appropriately sized

🤖 Generated with [Claude Code](https://claude.com/claude-code)